### PR TITLE
#2465429: Fix vagrant provisioner to not run build_all.sh anymore

### DIFF
--- a/provision.sh
+++ b/provision.sh
@@ -43,7 +43,6 @@ else
         curl -s get.docker.io | sh 2>&1 | egrep -i -v "Ctrl|docker installed"
         usermod -a -G docker vagrant
 	cd /home/vagrant/drupalci_testbot
-        ./scripts/build_all.sh cleanup $database
 	touch PROVISIONED
 fi
 


### PR DESCRIPTION
See [Issue #2465429](https://www.drupal.org/node/2465429)
